### PR TITLE
fix(FodyWeavers): add missing weaver file

### DIFF
--- a/FodyWeavers.xml
+++ b/FodyWeavers.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Weavers>
+  <Malimbe.FodyRunner>
+    <AssemblyNameRegex>^Tilia.CameraRigs.XRPluginFramework</AssemblyNameRegex>
+  </Malimbe.FodyRunner>
+</Weavers>

--- a/FodyWeavers.xml.meta
+++ b/FodyWeavers.xml.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: de01b53c3d7f9ab4cb3d09beceab5dab
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Whilst there is no definite need for a Fody Weaver file in this repo,
it is worth adding it for consistency with other repos that have code.