### PR TITLE
feat(DeviceDetails): add defaults for passthrough camera details

### DIFF
--- a/Documentation/API/XRFrameworkNodeRecord.md
+++ b/Documentation/API/XRFrameworkNodeRecord.md
@@ -8,6 +8,7 @@ Provides the description for a XR Plugin Framework CameraRig node element.
 * [Namespace]
 * [Syntax]
 * [Properties]
+  * [HasPassThroughCamera]
   * [NodeType]
   * [Priority]
   * [XRNodeType]
@@ -32,6 +33,14 @@ public class XRFrameworkNodeRecord : BaseDeviceDetailsRecord
 ```
 
 ### Properties
+
+#### HasPassThroughCamera
+
+##### Declaration
+
+```
+public override bool HasPassThroughCamera { get; protected set; }
+```
 
 #### NodeType
 
@@ -83,6 +92,7 @@ public virtual void SetNodeType(int index)
 [Namespace]: #Namespace
 [Syntax]: #Syntax
 [Properties]: #Properties
+[HasPassThroughCamera]: #HasPassThroughCamera
 [NodeType]: #NodeType
 [Priority]: #Priority
 [XRNodeType]: #XRNodeType

--- a/Runtime/SharedResources/Scripts/XRFrameworkNodeRecord.cs
+++ b/Runtime/SharedResources/Scripts/XRFrameworkNodeRecord.cs
@@ -32,6 +32,8 @@ namespace Tilia.CameraRigs.XRPluginFramework
         public override XRNode XRNodeType { get { return NodeType; } protected set { NodeType = value; } }
         /// <inheritdoc/>
         public override int Priority { get => 0; protected set => throw new System.NotImplementedException(); }
+        /// <inheritdoc/>
+        public override bool HasPassThroughCamera { get => false; protected set => throw new System.NotImplementedException(); }
 
         /// <summary>
         /// Sets the <see cref="NodeType"/>.

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "url": "https://github.com/ExtendRealityLtd"
     },
     "dependencies": {
-        "io.extendreality.zinnia.unity": "2.6.0",
+        "io.extendreality.zinnia.unity": "2.7.0",
         "com.unity.xr.management": "4.0.1"
     },
     "files": [


### PR DESCRIPTION
The DeviceDetailsRecord now supports passthrough camera options and therefore anything that derrives from that needs to implement the base interfaces even if they don't support camera passthrough yet.